### PR TITLE
Replace prints with logging calls

### DIFF
--- a/citation_generator.py
+++ b/citation_generator.py
@@ -156,7 +156,7 @@ class CitationGenerator:
         try:
             response = self.gemini_api.generate_content(prompt + "\n\nText:\n" + text)
 
-            print(response)
+            logger.debug(response)
             
             # Clean the response - remove any non-JSON content
             json_str = response.strip()

--- a/figure_generator.py
+++ b/figure_generator.py
@@ -70,7 +70,7 @@ class FigureGenerator:
                 figure_data = self._analyze_chapter_for_figures(chapter_file, figure_images, extracted_text)
                 if figure_data:
                     # Update chapter with figure references
-                    print(figure_data)
+                    logger.debug(f"Figure data: {figure_data}")
                     self._update_chapter_figures(chapter_file, figure_data, debug_folder)
                     logger.info(f"Added figure references to {os.path.basename(chapter_file)}")
                 else:

--- a/page_classifier.py
+++ b/page_classifier.py
@@ -195,7 +195,7 @@ class PageClassifier:
             logger.error("No classification result received from API")
             return {}
             
-        print("Classification result:", classification_result)
+        logger.debug("Classification result: %s", classification_result)
 
         # Process each category
         categorized_content = {}

--- a/text_extractor.py
+++ b/text_extractor.py
@@ -113,7 +113,7 @@ class TextExtractor:
             text = self.extract_text_from_image(image, previous_paragraph)
             
             if text:
-                print(f"Page {page_num}:\n{text}\n\n")
+                logger.debug("Page %s:\n%s\n\n", page_num, text)
                 extracted_data[f"Page {page_num}"] = text
                 previous_paragraph = text
             else:

--- a/yaml_metadata_generator.py
+++ b/yaml_metadata_generator.py
@@ -109,11 +109,11 @@ class YamlMetadataGenerator:
                     intro_content = f.read()
             
             metadata = self.extract_metadata_from_intro(intro_content)
-            print(metadata)
+            logger.debug(metadata)
             
             # Generate abstract
             abstract = self.generate_abstract(chapters_content)
-            print(abstract)
+            logger.debug(abstract)
             
             # Create YAML content
             yaml_template = "---\n"


### PR DESCRIPTION
## Summary
- convert `print()` calls to logger calls across the project
- keep debug info but direct it through Python logging

## Testing
- `pytest -q`